### PR TITLE
refactor: Integrate GTID replication and monitoring stack for distributed WordPress cluster

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,15 @@
+[defaults]
+roles_path = ./roles
+inventory   = ./inventory.yml
+stdin_prompt = false
+deprecation_warnings = false
+retry_files_enabled  = false
+stdout_callback      = yaml
+host_key_checking    = false
+
+[privilege_escalation]
+become        = true
+become_method = sudo
+
+[ssh_connection]
+pipelining = true

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,17 +1,57 @@
-database_name: wordpress_db
+---
+is_wordpress: true
+wordpress_port: 8080
+wordpress_db_name: wordpress_db
+
+mysql_root_password: root_password
+db_pass: "{{ mysql_root_password }}"
+
+database_name: "{{ wordpress_db_name }}"
 database_user: wordpress_user
 database_password: wordpress_password
-mysql_root_password: root_password
 
 replication_user: repl
 replication_password: replication_password
 
+db_host: mysql_master
+db_master: mysql_master
+db_replica: "mysql_slave1,mysql_slave2"
+
 wordpress_admin_user: admin
 wordpress_admin_password: admin_password
 wordpress_admin_email: admin@example.com
-wordpress_site_url: "http://{{ inventory_hostname }}:8080"
+wordpress_site_url: "http://{{ hostvars['carrier'].ansible_host }}:{{ wordpress_port }}"
 
 docker_network: wordpress-network
 docker_compose_version: '3.8'
-
 project_root: "/opt/wordpress"
+docker_exact_version: "5:28.0.4"
+
+monitoring_url: "http://{{ hostvars['carrier'].ansible_host }}:3000"
+
+cadvisor_port: 8081
+prometheus_port: 9091
+grafana_port: 3000
+
+cadvisor_container_name: cadvisor
+cadvisor_image: gcr.io/cadvisor/cadvisor:latest
+cadvisor_ports: "{{ cadvisor_port }}:8080"
+cadvisor_volume_path_root: /:/rootfs:ro
+cadvisor_volume_path_var: /var/run:/var/run:ro
+cadvisor_volume_path_sys: /sys:/sys:ro
+
+prometheus_container_name: prometheus
+prometheus_image: prom/prometheus:latest
+prometheus_restart_policy: always
+prometheus_data_path: /opt/prometheus
+prometheus_volume: "/opt/prometheus:/etc/prometheus"
+prometheus_ports: "{{ prometheus_port }}:9090"
+
+grafana_container_name: grafana
+grafana_image: grafana/grafana:latest
+grafana_restart_policy: always
+grafana_data_path: /opt/grafana
+grafana_admin_user: admin
+grafana_admin_password: admin
+grafana_users_allow_sign_up: 'false'
+grafana_ports: "{{ grafana_port }}:3000"

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,9 +1,10 @@
 all:
   hosts:
     carrier:
-      ansible_host: 192.168.XXX.XXX
-      ansible_user: XXXXXXXX
-      ansible_password: XXXXXXXX
+      ansible_host: 83.220.168.126
+      ansible_user: ifmo_ansible_user
+      ansible_password: ifmo_ansible_password
       ansible_become_method: sudo
-      ansible_become_pass: XXXXXXXX
+      ansible_become_pass: ifmo_ansible_password
       ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+      ansible_connection: paramiko  # Обрабатывает пароль внутри Python-кода

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,2 +1,0 @@
-[wordpress_server]
-158.160.24.58 ansible_user=admin ansible_ssh_private_key_file=~/.ssh/id-ed25519-distr-yandex-cloud

--- a/playbook1.yml
+++ b/playbook1.yml
@@ -1,12 +1,17 @@
 ---
 - name: Home work 1
   hosts: carrier
+
   tasks:
     - name: Display Configuration Variables
       ansible.builtin.debug:
         msg:
-          - "wordpress: {{ is_wordpress }}" # True or False
-          - "wordpress_port: {{ wordpress_port }}" # 80 or 8080 or whatewer
-          - "wordpress_db_name: {{ wordpress_db_name }}" # WP database name
-          - "db_host: {{ db_host }}" # container name
-          - "db_pass: {{ db_pass }}" # root password
+          - "wordpress: {{ is_wordpress }}"
+          - "wordpress_port: {{ wordpress_port }}"
+          - "wordpress_db_name: {{ wordpress_db_name }}"
+          - "db_host: {{ db_host }}"
+          - "db_pass: {{ db_pass }}"
+
+  roles:
+    - docker_setup      # установка Docker и docker-compose
+    - wordpress_setup   # WP + Nginx + MySQL (master + slaves)

--- a/playbook2.yml
+++ b/playbook2.yml
@@ -1,13 +1,17 @@
 ---
 - name: Home work 2
   hosts: carrier
+
   tasks:
     - name: Display Configuration Variables
       ansible.builtin.debug:
         msg:
-          - "wordpress: {{ is_wordpress }}" # True or False
-          - "wordpress_port: {{ wordpress_port }}" # 80 or 8080 or whatewer
-          - "wordpress_db_name: {{ wordpress_db_name }}" # WP database name
-          - "db_master: {{ db_master }}" # container name
-          - "db_replica: {{ db_replica }}" # container name
-          - "db_pass: {{ db_pass }}" # root password for master and replica
+          - "wordpress: {{ is_wordpress }}"
+          - "wordpress_port: {{ wordpress_port }}"
+          - "wordpress_db_name: {{ wordpress_db_name }}"
+          - "db_master: {{ db_master }}"
+          - "db_replica: {{ db_replica }}"
+          - "db_pass: {{ db_pass }}"
+
+  roles:
+    - db_setup          # мастер-реплика-реплика + GTID + валидация

--- a/playbook3.yml
+++ b/playbook3.yml
@@ -1,8 +1,14 @@
 ---
 - name: Home work 3
   hosts: carrier
+
   tasks:
     - name: Display Configuration Variables
       ansible.builtin.debug:
         msg:
-          - "monitoring_url: {{ monitoring_url }}" # monitoring url including port
+          - "monitoring_url: {{ monitoring_url }}"
+
+  roles:
+    - cadvisor
+    - prometheus
+    - grafana

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
+---
 collections:
   - name: community.docker
     version: ">=4.5.0"

--- a/roles/cadvisor/tasks/main.yml
+++ b/roles/cadvisor/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Run cAdvisor container
+  community.docker.docker_container:
+    name: "{{ cadvisor_container_name }}"
+    image: "{{ cadvisor_image }}"
+    restart_policy: always
+    ports:
+      - "{{ cadvisor_ports }}"
+    volumes:
+      - "{{ cadvisor_volume_path_root }}"
+      - "{{ cadvisor_volume_path_var }}"
+      - "{{ cadvisor_volume_path_sys }}"
+    networks:
+      - name: "{{ docker_network }}"
+
+- name: Confirm cAdvisor is live
+  ansible.builtin.debug:
+    msg: "cAdvisor → http://{{ hostvars[inventory_hostname].ansible_host }}:{{ cadvisor_port }}"
+  changed_when: false

--- a/roles/db_setup/tasks/configure_replica.yml
+++ b/roles/db_setup/tasks/configure_replica.yml
@@ -1,0 +1,67 @@
+---
+- name: Wait until {{ slave_container }} is healthy
+  community.docker.docker_container_info:
+    name: "{{ slave_container }}"
+  register: slave_info
+  until: slave_info.container.State.Health.Status == 'healthy'
+  retries: 30
+  delay: 5
+
+- name: Capture slave IP
+  ansible.builtin.set_fact:
+    slave_ip: "{{ slave_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
+
+- name: Stop replica if running
+  community.mysql.mysql_replication:
+    mode: stopreplica
+    login_host: "{{ slave_ip }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  ignore_errors: true
+
+- name: Ensure replica configured for master
+  community.mysql.mysql_replication:
+    mode: changeprimary
+    login_host: "{{ slave_ip }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    primary_host: mysql_master
+    primary_user: "{{ replication_user }}"
+    primary_password: "{{ replication_password }}"
+    primary_auto_position: yes
+    primary_ssl: yes
+  register: replica_changed
+
+- name: Start replica (only if changed)
+  community.mysql.mysql_replication:
+    mode: startreplica
+    login_host: "{{ slave_ip }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  when: replica_changed.changed
+
+- name: Wait until replication lag ≤ 2 s on {{ slave_container }}
+  community.mysql.mysql_replication:
+    mode: getreplica
+    login_host: "{{ slave_ip }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  register: repl_status
+  until: (repl_status.Replica_IO_Running == 'Yes') and
+         (repl_status.Replica_SQL_Running == 'Yes') and
+         ((repl_status.Seconds_Behind_Source | int) <= 2)
+  retries: 20
+  delay: 6
+
+- name: Assert wordpress_db exists on {{ slave_container }}
+  community.mysql.mysql_query:
+    login_host: "{{ slave_ip }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    query: "SHOW DATABASES LIKE '{{ wordpress_db_name }}'"
+  register: db_check
+
+- name: Fail if DB absent on {{ slave_container }}
+  ansible.builtin.fail:
+    msg: "wordpress_db missing on {{ slave_container }}"
+  when: db_check.rowcount == 0

--- a/roles/db_setup/tasks/main.yml
+++ b/roles/db_setup/tasks/main.yml
@@ -1,29 +1,29 @@
+---
 - name: Wait until MySQL master is healthy
   community.docker.docker_container_info:
     name: mysql_master
   register: master_info
   until: master_info.container.State.Health.Status == 'healthy'
-  retries: 20
-  delay: 10
+  retries: 30
+  delay: 5
 
 - name: Capture MySQL master IP
-  set_fact:
+  ansible.builtin.set_fact:
     master_ip: "{{ master_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
 
-- name: Ensure replication user exists with appropriate settings
+- name: Ensure replication user exists (idempotent)
   community.mysql.mysql_query:
     login_host: "{{ master_ip }}"
     login_user: root
     login_password: "{{ mysql_root_password }}"
+    single_transaction: true
     query:
-      - |
-        DROP USER IF EXISTS '{{ replication_user }}'@'%';
-      - |
-        CREATE USER '{{ replication_user }}'@'%' IDENTIFIED BY '{{ replication_password }}';
-      - |
+      - >-
+        CREATE USER IF NOT EXISTS '{{ replication_user }}'@'%'
+        IDENTIFIED WITH caching_sha2_password BY '{{ replication_password }}'
+        REQUIRE SSL;
+      - >-
         GRANT REPLICATION SLAVE ON *.* TO '{{ replication_user }}'@'%';
-      - |
-        ALTER USER '{{ replication_user }}'@'%' REQUIRE SSL;
       - FLUSH PRIVILEGES;
   changed_when: false
 
@@ -33,11 +33,17 @@
   register: legacy_vol
   failed_when: false
 
+- name: Create temporary file for dump
+  ansible.builtin.tempfile:
+    state: file
+    suffix: ".sql"
+  register: dump_tmp
+  when: legacy_vol.exists | default(false)
+
 - name: Start temporary legacy MySQL container
   community.docker.docker_container:
     name: mysql_legacy
     image: mysql:8.4.4
-    detach: true
     env:
       MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
     volumes:
@@ -57,20 +63,15 @@
     name: mysql_legacy
   register: legacy_info
   until: legacy_info.container.State.Health.Status == 'healthy'
-  retries: 20
-  delay: 10
-  when: legacy_vol.exists | default(false)
-
-- name: Capture legacy MySQL IP
-  set_fact:
-    legacy_ip: "{{ legacy_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
+  retries: 30
+  delay: 5
   when: legacy_vol.exists | default(false)
 
 - name: Dump all databases from legacy
   community.mysql.mysql_db:
     state: dump
-    target: /tmp/legacy_dump.sql
-    login_host: "{{ legacy_ip }}"
+    target: "{{ dump_tmp.path }}"
+    login_host: "{{ legacy_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
     login_user: root
     login_password: "{{ mysql_root_password }}"
     single_transaction: yes
@@ -80,7 +81,7 @@
 - name: Import dump into master
   community.mysql.mysql_db:
     state: import
-    target: /tmp/legacy_dump.sql
+    target: "{{ dump_tmp.path }}"
     login_host: "{{ master_ip }}"
     login_user: root
     login_password: "{{ mysql_root_password }}"
@@ -93,183 +94,12 @@
     force_kill: true
   when: legacy_vol.exists | default(false)
 
-- name: Wait until MySQL slave1 is healthy
-  community.docker.docker_container_info:
-    name: mysql_slave1
-  register: slave1_info
-  until: slave1_info.container.State.Health.Status == 'healthy'
-  retries: 20
-  delay: 10
+- name: Collect slaves into a list
+  ansible.builtin.set_fact:
+    slave_names: ["mysql_slave1", "mysql_slave2"]
 
-- name: Wait until MySQL slave2 is healthy
-  community.docker.docker_container_info:
-    name: mysql_slave2
-  register: slave2_info
-  until: slave2_info.container.State.Health.Status == 'healthy'
-  retries: 20
-  delay: 10
-
-- name: Capture slaves IPs
-  set_fact:
-    slave1_ip: "{{ slave1_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
-    slave2_ip: "{{ slave2_info.container.NetworkSettings.Networks[docker_network].IPAddress }}"
-
-- name: Stop replication on slave1
-  community.mysql.mysql_replication:
-    mode: stopreplica
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-  ignore_errors: true
-
-- name: Reset replica on slave1
-  community.mysql.mysql_query:
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    query: "RESET REPLICA ALL;"
-  changed_when: false
-  ignore_errors: true
-
-- name: Configure replication on slave1
-  community.mysql.mysql_replication:
-    mode: changeprimary
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    primary_host: mysql_master
-    primary_user: "{{ replication_user }}"
-    primary_password: "{{ replication_password }}"
-    primary_auto_position: yes
-    primary_ssl: yes
-
-- name: Start replication on slave1
-  community.mysql.mysql_replication:
-    mode: startreplica
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-
-- name: Stop replication on slave2
-  community.mysql.mysql_replication:
-    mode: stopreplica
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-  ignore_errors: true
-
-- name: Reset replica on slave2
-  community.mysql.mysql_query:
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    query: "RESET REPLICA ALL;"
-  changed_when: false
-  ignore_errors: true
-
-- name: Configure replication on slave2
-  community.mysql.mysql_replication:
-    mode: changeprimary
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    primary_host: mysql_master
-    primary_user: "{{ replication_user }}"
-    primary_password: "{{ replication_password }}"
-    primary_auto_position: yes
-    primary_ssl: yes
-
-- name: Start replication on slave2
-  community.mysql.mysql_replication:
-    mode: startreplica
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-
-- name: Wait for data to replicate (10 seconds)
-  pause:
-    seconds: 10
-  when: (ansible_check_mode|bool) == false
-
-- name: Check replication status on slave1
-  community.mysql.mysql_replication:
-    mode: getreplica
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-  register: repl1_status
-
-- name: Check replication status on slave2
-  community.mysql.mysql_replication:
-    mode: getreplica
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-  register: repl2_status
-
-- name: Check if replica IO thread is running on slave1
-  fail:
-    msg: "Replica IO thread is not running on slave1. Status: {{ repl1_status.Replica_IO_Running }}"
-  when: repl1_status.Replica_IO_Running != 'Yes'
-
-- name: Check if replica SQL thread is running on slave1
-  fail:
-    msg: "Replica SQL thread is not running on slave1. Status: {{ repl1_status.Replica_SQL_Running }}"
-  when: repl1_status.Replica_SQL_Running != 'Yes'
-
-- name: Check if replica IO thread is running on slave2
-  fail:
-    msg: "Replica IO thread is not running on slave2. Status: {{ repl2_status.Replica_IO_Running }}"
-  when: repl2_status.Replica_IO_Running != 'Yes'
-
-- name: Check if replica SQL thread is running on slave2
-  fail:
-    msg: "Replica SQL thread is not running on slave2. Status: {{ repl2_status.Replica_SQL_Running }}"
-  when: repl2_status.Replica_SQL_Running != 'Yes'
-
-- name: Display replication delay on slave1
-  debug:
-    msg: "Replica delay on slave1: {{ repl1_status.Seconds_Behind_Source | default('N/A') }} seconds"
-
-- name: Display replication delay on slave2
-  debug:
-    msg: "Replica delay on slave2: {{ repl2_status.Seconds_Behind_Source | default('N/A') }} seconds"
-
-- name: Check for wordpress_db on master
-  community.mysql.mysql_query:
-    login_host: "{{ master_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    query: "SHOW DATABASES LIKE 'wordpress_db'"
-  register: master_db
-
-- name: Check for wordpress_db on slave1
-  community.mysql.mysql_query:
-    login_host: "{{ slave1_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    query: "SHOW DATABASES LIKE 'wordpress_db'"
-  register: slave1_db
-
-- name: Check for wordpress_db on slave2
-  community.mysql.mysql_query:
-    login_host: "{{ slave2_ip }}"
-    login_user: root
-    login_password: "{{ mysql_root_password }}"
-    query: "SHOW DATABASES LIKE 'wordpress_db'"
-  register: slave2_db
-
-- name: Verify wordpress_db exists on slave1
-  fail:
-    msg: "wordpress_db does not exist on slave1"
-  when: slave1_db.rowcount == 0
-
-- name: Verify wordpress_db exists on slave2
-  fail:
-    msg: "wordpress_db does not exist on slave2"
-  when: slave2_db.rowcount == 0
-
-- name: Display DB cluster ready message
-  debug:
-    msg: "Master-Replica-Replica replication configured successfully with verified data replication."
-  changed_when: false
+- name: Configure replication on each slave
+  ansible.builtin.include_tasks: configure_replica.yml
+  loop: "{{ slave_names }}"
+  loop_control:
+    loop_var: slave_container

--- a/roles/docker_setup/tasks/main.yml
+++ b/roles/docker_setup/tasks/main.yml
@@ -1,7 +1,8 @@
+---
 - name: Gather installed package facts
   package_facts:
     manager: apt
-  
+
 - name: Check if Docker is already installed
   debug:
     msg: "Docker CE {{ ansible_facts.packages['docker-ce'][0].version if 'docker-ce' in ansible_facts.packages else 'not installed' }}"
@@ -51,7 +52,7 @@
     url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
     state: present
   become: yes
-  when: not docker_version_ok|default(true) or not compose_plugin_version_ok|default(true)
+  when: not docker_version_ok | default(true) or not compose_plugin_version_ok | default(true)
 
 - name: Add Docker repository
   apt_repository:
@@ -60,7 +61,7 @@
     filename: docker
     update_cache: yes
   become: yes
-  when: not docker_version_ok|default(true) or not compose_plugin_version_ok|default(true)
+  when: not docker_version_ok | default(true) or not compose_plugin_version_ok | default(true)
 
 - name: Install Docker Engine with specific version
   apt:
@@ -71,15 +72,15 @@
     state: present
     update_cache: yes
   become: yes
-  when: not docker_version_ok|default(true)
+  when: not docker_version_ok | default(true)
 
-- name: Install Docker Compose Plugin with minimum version
+- name: Install or upgrade Docker Compose Plugin (ensure ≥ {{ compose_plugin_min_version }})
   apt:
-    name: "docker-compose-plugin={{ compose_plugin_min_version }}*"
-    state: present
+    name: docker-compose-plugin
+    state: latest          # ← ставим последнюю доступную версию
     update_cache: yes
   become: yes
-  when: not compose_plugin_version_ok|default(true)
+  when: not compose_plugin_version_ok | default(true)
 
 - name: Install Python Docker SDK on remote host
   apt:

--- a/roles/grafana/files/datasource.yml
+++ b/roles/grafana/files/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    isDefault: true
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,0 +1,34 @@
+- name: Ensure Grafana data dir exists
+  ansible.builtin.file:
+    path: "{{ grafana_data_path }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Copy Grafana datasource
+  ansible.builtin.copy:
+    src: datasource.yml
+    dest: "{{ grafana_data_path }}/datasource.yml"
+    mode: '0644'
+  become: true
+
+- name: Run Grafana container
+  community.docker.docker_container:
+    name: "{{ grafana_container_name }}"
+    image: "{{ grafana_image }}"
+    restart_policy: "{{ grafana_restart_policy }}"
+    env:
+      GF_SECURITY_ADMIN_USER: "{{ grafana_admin_user }}"
+      GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_admin_password }}"
+      GF_USERS_ALLOW_SIGN_UP: "{{ grafana_users_allow_sign_up }}"
+    ports:
+      - "{{ grafana_ports }}"
+    volumes:
+      - "{{ grafana_data_path }}/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml"
+    networks:
+      - name: "{{ docker_network }}"
+
+- name: Confirm Grafana is live
+  ansible.builtin.debug:
+    msg: "Grafana → http://{{ hostvars[inventory_hostname].ansible_host }}:{{ grafana_port }}"
+  changed_when: false

--- a/roles/prometheus/files/prometheus.yml
+++ b/roles/prometheus/files/prometheus.yml
@@ -1,0 +1,9 @@
+---
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Ensure Prometheus data dir exists
+  ansible.builtin.file:
+    path: "{{ prometheus_data_path }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Copy Prometheus config
+  ansible.builtin.copy:
+    src: prometheus.yml
+    dest: "{{ prometheus_data_path }}/prometheus.yml"
+    mode: '0644'
+  become: true
+
+- name: Run Prometheus container
+  community.docker.docker_container:
+    name: "{{ prometheus_container_name }}"
+    image: "{{ prometheus_image }}"
+    restart_policy: "{{ prometheus_restart_policy }}"
+    ports:
+      - "{{ prometheus_ports }}"
+    volumes:
+      - "{{ prometheus_volume }}"
+    networks:
+      - name: "{{ docker_network }}"
+
+- name: Confirm Prometheus is live
+  ansible.builtin.debug:
+    msg: "Prometheus → http://{{ hostvars[inventory_hostname].ansible_host }}:{{ prometheus_port }}"
+  changed_when: false

--- a/roles/wordpress_setup/tasks/main.yml
+++ b/roles/wordpress_setup/tasks/main.yml
@@ -1,4 +1,52 @@
+---
+- name: Wait until wordpress_app is healthy or simply running
+  community.docker.docker_container_info:
+    name: wordpress_app
+  register: wp_info
+  until: >
+    (wp_info.container.State.Health is defined and
+     wp_info.container.State.Health.Status == 'healthy') or
+    (wp_info.container.State.Health is not defined and
+     wp_info.container.State.Status == 'running')
+  retries: 30
+  delay: 4
+
+- name: Install WP-CLI in container (idempotent)
+  community.docker.docker_container_exec:
+    container: wordpress_app
+    command: >
+      bash -c "command -v wp ||
+               curl -s -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar &&
+               chmod +x wp-cli.phar &&
+               mv wp-cli.phar /usr/local/bin/wp"
+  register: wp_cli_install
+  changed_when: "'wp-cli.phar' in wp_cli_install.stdout"
+
+- name: Check if WordPress core is installed
+  community.docker.docker_container_exec:
+    container: wordpress_app
+    command: wp core is-installed --path=/var/www/html --allow-root
+  register: wp_core_check
+  failed_when: false
+  changed_when: false
+
+- name: Install WordPress core
+  community.docker.docker_container_exec:
+    container: wordpress_app
+    command: >
+      wp core install
+        --url='{{ wordpress_site_url }}'
+        --title='WordPress on Docker'
+        --admin_user='{{ wordpress_admin_user }}'
+        --admin_password='{{ wordpress_admin_password }}'
+        --admin_email='{{ wordpress_admin_email }}'
+        --path=/var/www/html
+        --allow-root
+  when: wp_core_check.rc != 0
+  register: wp_core_install
+  changed_when: "'WordPress has been installed' in wp_core_install.stdout"
+
 - name: Display final WordPress setup message
-  debug:
-    msg: "WordPress setup role completed. Nginx + PHP-FPM environment is ready."
+  ansible.builtin.debug:
+    msg: "WordPress + Nginx/PHP-FPM готовы: {{ wordpress_site_url }}"
   changed_when: false

--- a/site.yml
+++ b/site.yml
@@ -1,9 +1,0 @@
-- name: Deploy a Fully Containerized WordPress with Nginx and MySQL
-  hosts: wordpress_server
-  become: yes
-
-  roles:
-    - docker_setup
-    - db_setup
-    - wordpress_setup
-


### PR DESCRIPTION
#comment Refactor WordPress deployment and monitoring infrastructure for Homework 3 of Distributed Computing course:

1. Modularize MySQL replication logic into reusable task configure_replica.yml with GTID and health validation.
2. Introduce cAdvisor container for Docker-level performance metrics.
3. Provision Prometheus service with external scrape configuration for cAdvisor.
4. Provision Grafana container with predefined Prometheus datasource.
5. Automate WordPress container initialization with WP-CLI core installation.
6. Refactor docker_setup to ensure idempotent installation of Docker, Compose and SDKs.
7. Consolidate ansible.cfg and inventory.yml to support password-based connection with paramiko.
8. Remove deprecated site.yml and static inventory/hosts.ini
9. Improve playbooks modularity and role separation across playbook1.yml, playbook2.yml, and playbook3.yml

Affected: ansible.cfg, group_vars/all.yml, inventory.yml, playbook1.yml, playbook2.yml, playbook3.yml, requirements.yml, roles/cadvisor/tasks/main.yml, roles/db_setup/tasks/configure_replica.yml, roles/db_setup/tasks/main.yml, roles/docker_setup/tasks/main.yml, roles/grafana/files/datasource.yml, roles/grafana/tasks/main.yml, roles/prometheus/files/prometheus.yml, roles/prometheus/tasks/main.yml, roles/wordpress_setup/tasks/main.yml, .ansible-lint.yaml, .github/workflows/ansible-lint.yml, site.yml, inventory/hosts.ini