### PR TITLE
fix: Allow root user connections from any host in Galera cluster

### DIFF
--- a/roles/galera_cluster/tasks/manage_galera.yml
+++ b/roles/galera_cluster/tasks/manage_galera.yml
@@ -6,6 +6,7 @@
     restart_policy: unless-stopped
     env:
       MARIADB_ROOT_PASSWORD: "{{ db_root_password }}"
+      MARIADB_ROOT_HOST: "%"
       MARIADB_USER: "{{ mariadb_user }}"
       MARIADB_PASSWORD: "{{ mariadb_password }}"
       MARIADB_DATABASE: "{{ wordpress_db_name }}"

--- a/roles/galera_cluster/tasks/wait_container_healthy.yml
+++ b/roles/galera_cluster/tasks/wait_container_healthy.yml
@@ -6,6 +6,7 @@
     restart_policy: unless-stopped
     env:
       MARIADB_ROOT_PASSWORD: "{{ db_root_password }}"
+      MARIADB_ROOT_HOST: "%"
       MARIADB_USER: "{{ mariadb_user }}"
       MARIADB_PASSWORD: "{{ mariadb_password }}"
       MARIADB_DATABASE: "{{ wordpress_db_name }}"


### PR DESCRIPTION
#comment Configure MARIADB_ROOT_HOST environment variable to '%' in all Galera nodes to resolve connection rejection error (1130) when Ansible attempts to connect from Docker host IP address.

Affected: manage_galera.yml, wait_container_healthy.yml